### PR TITLE
fix: Stop using the InstallTrigger API to detect Firefox

### DIFF
--- a/v2/firefox/data/commander/components/directory-view/list-view.js
+++ b/v2/firefox/data/commander/components/directory-view/list-view.js
@@ -476,7 +476,7 @@ class ListView extends HTMLElement {
     }));
   }
   favicon(href) {
-    if (typeof InstallTrigger !== 'undefined') {
+    if (/Firefox/.test(navigator.userAgent)) {
       if (this.config.remote) {
         return 'http://www.google.com/s2/favicons?domain_url=' + href;
       }

--- a/v2/firefox/data/commander/engine.js
+++ b/v2/firefox/data/commander/engine.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const bookmarks = {
-  rootID: typeof InstallTrigger !== 'undefined' ? 'root________' : '0',
+  rootID: /Firefox/.test(navigator.userAgent) ? 'root________' : '0',
   isRoot(id) {
     return id === '' || id === bookmarks.rootID;
   },

--- a/v3/data/commander/components/directory-view/list-view.js
+++ b/v3/data/commander/components/directory-view/list-view.js
@@ -561,7 +561,7 @@ class ListView extends HTMLElement {
     }));
   }
   favicon(href) {
-    if (typeof InstallTrigger !== 'undefined') {
+    if (/Firefox/.test(navigator.userAgent)) {
       if (this.config.remote) {
         return 'http://www.google.com/s2/favicons?domain_url=' + href;
       }

--- a/v3/data/commander/engine.js
+++ b/v3/data/commander/engine.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const bookmarks = {
-  rootID: typeof InstallTrigger !== 'undefined' ? 'root________' : '0',
+  rootID: /Firefox/.test(navigator.userAgent) ? 'root________' : '0',
   isRoot(id) {
     return id === '' || id === bookmarks.rootID;
   },


### PR DESCRIPTION
The InstallTrigger API has been [deprecated since Firefox version 100](https://bugzilla.mozilla.org/show_bug.cgi?id=1754441). On recent builds of Firefox Developer Edition, it is undefined, causing `rootID` to be set to `"0"`. On Firefox-based browsers, calling `bookmarks.getChildren()` with this value throws an error.

This commit changes this browser detection technique to User Agent matching.